### PR TITLE
Fix: Use Xdebug for collecting code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         uses: "shivammathur/setup-php@v1"
         with:
           php-version: "${{ matrix.php-version }}"
-          coverage: "pcov"
+          coverage: "xdebug"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v1"


### PR DESCRIPTION
This PR

* [x] uses `Xdebug` for collection code coverage

Follows #8.

💁‍♂ The version of `phpunit/phpunit` that is currently required does not have support for `pcov`.